### PR TITLE
Register plugin outside of AppDelegate

### DIFF
--- a/ios/VisionCameraCodeScanner.h
+++ b/ios/VisionCameraCodeScanner.h
@@ -1,0 +1,5 @@
+#import <VisionCamera/FrameProcessorPlugin.h>
+
+@interface RegisterPlugins : FrameProcessorPlugin
+
+@end

--- a/ios/VisionCameraCodeScanner.m
+++ b/ios/VisionCameraCodeScanner.m
@@ -1,7 +1,11 @@
 #import <Foundation/Foundation.h>
 
 #import "VisionCameraCodeScanner.h"
+#if defined __has_include && __has_include("VisionCameraCodeScanner-Swift.h")
 #import "VisionCameraCodeScanner-Swift.h"
+#else
+#import <VisionCameraCodeScanner/VisionCameraCodeScanner-Swift.h>
+#endif
 
 @implementation RegisterPlugins
 

--- a/ios/VisionCameraCodeScanner.m
+++ b/ios/VisionCameraCodeScanner.m
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+#import "VisionCameraCodeScanner.h"
+#import "VisionCameraCodeScanner-Swift.h"
+
+@implementation RegisterPlugins
+
+    + (void) load {
+        [self registerPlugin:[[VisionCameraCodeScanner alloc] init]];
+    }
+
+@end

--- a/ios/VisionCameraCodeScanner.xcodeproj/project.pbxproj
+++ b/ios/VisionCameraCodeScanner.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 				PRODUCT_NAME = VisionCameraCodeScanner;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "VisionCameraCodeScanner-Bridging-Header.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "VisionCameraCodeScanner-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -252,6 +253,7 @@
 				PRODUCT_NAME = VisionCameraCodeScanner;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "VisionCameraCodeScanner-Bridging-Header.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "VisionCameraCodeScanner-Swift.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/ios/VisionCameraCodeScanner.xcodeproj/project.pbxproj
+++ b/ios/VisionCameraCodeScanner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		214AF74C2A0A098B000437BC /* VisionCameraCodeScanner.m in Sources */ = {isa = PBXBuildFile; fileRef = 214AF74B2A0A098B000437BC /* VisionCameraCodeScanner.m */; };
 		F4FF95D7245B92E800C19C63 /* VisionCameraCodeScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* VisionCameraCodeScanner.swift */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libVisionCameraCodeScanner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libVisionCameraCodeScanner.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		214AF74A2A0A094F000437BC /* VisionCameraCodeScanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VisionCameraCodeScanner.h; sourceTree = "<group>"; };
+		214AF74B2A0A098B000437BC /* VisionCameraCodeScanner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VisionCameraCodeScanner.m; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* VisionCameraCodeScanner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VisionCameraCodeScanner-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* VisionCameraCodeScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionCameraCodeScanner.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -50,6 +53,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				214AF74B2A0A098B000437BC /* VisionCameraCodeScanner.m */,
+				214AF74A2A0A094F000437BC /* VisionCameraCodeScanner.h */,
 				F4FF95D6245B92E800C19C63 /* VisionCameraCodeScanner.swift */,
 				F4FF95D5245B92E700C19C63 /* VisionCameraCodeScanner-Bridging-Header.h */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -113,6 +118,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214AF74C2A0A098B000437BC /* VisionCameraCodeScanner.m in Sources */,
 				F4FF95D7245B92E800C19C63 /* VisionCameraCodeScanner.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Maintains compatibility with Expo out of the box, without requiring prebuild or ejecting